### PR TITLE
Support for Custom Alpha Num Refs and Removal of Paystacks Secret key requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ class MyApp extends Component {
           buttonText="Pay Now"
           showPayButton={false}
           paystackKey="your-public-key-here"
-          paystackSecretKey="your-secret-key-here"
           amount={120000}
           billingEmail="paystackwebview@something.com"
           billingMobile="09787377462"
@@ -87,7 +86,6 @@ class MyApp extends Component {
           buttonText="Pay Now"
           showPayButton={false}
           paystackKey="your-public-key-here"
-          paystackSecretKey="your-secret-key-here"
           amount={120000}
           billingEmail="paystackwebview@something.com"
           billingMobile="09787377462"
@@ -135,7 +133,6 @@ function Pay(){
         <PaystackWebView
           showPayButton={false}
           paystackKey="your-public-key-here"
-          paystackSecretKey="your-secret-key-here"
           amount={120000}
           billingEmail="paystackwebview@something.com"
           billingMobile="09787377462"
@@ -176,7 +173,6 @@ const success = (e) =>{
         <PaystackWebView
           showPayButton={false}
           paystackKey="your-public-key-here"
-          paystackSecretKey="your-secret-key-here"
           amount={120000}
           billingEmail="paystackwebview@something.com"
           billingMobile="09787377462"
@@ -249,7 +245,6 @@ You can also make use of the new props `autoStart` to initiate payment once the 
 | `textStyles`                 |              Defines styles for text in button               |             `nill` |
 | `btnStyles`                  |                   Defines style for button                   |             `nill` |
 | `paystackKey`                | Public or Private paystack key(visit paystack.com to get yours) |             `nill` |
-| `paystackSecretKey`          |  Paystack Secret key(visit paystack.com to get yours)    |             `nill` |
 | `amount`                     |                      Amount to be paid                       |             `nill` |
 | `ActivityIndicatorColor`     |                       color of loader                        |   default: `green` |
 | `billingEmail(required by paystack)`               |                        Billers email                         |    default: `nill` |

--- a/index.js
+++ b/index.js
@@ -115,7 +115,6 @@ function Paystack(props, ref) {
         fetch(`https://api.paystack.co/transaction/verify/${reference}`, {
           method: "GET",
           headers: new Headers({
-            Authorization: "Bearer " + props.paystackSecretKey,
           }),
         })
           .then((response) => response.json())

--- a/index.js
+++ b/index.js
@@ -70,7 +70,7 @@ function Paystack(props, ref) {
                                 amount: ${props.amount}00, 
                                 channels: ${props.channels},
                                 currency: ${props.currency},
-                                ref: ${props.refNumber}, // generates a pseudo-unique reference. Please replace with a reference you generated. Or remove the line entirely so our API will generate one for you
+                                ref: '${props.refNumber}', // generates a pseudo-unique reference. Please replace with a reference you generated. Or remove the line entirely so our API will generate one for you
                                 metadata: {
                                 custom_fields: [
                                         {


### PR DESCRIPTION
Added a minor fix to allow support for custom/user supplied alpha numeric reference numbers, while also removing requirement for Paystacks secret key.