### PR TITLE
📝 Docs (Readme): fix 2nd code example on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,11 +103,11 @@ class MyApp extends Component {
           }}
           autoStart={false}
           refNumber={uuid()} // this is only for cases where you have a reference number generated
-          renderButton=((onPress) => {
+          renderButton={(onPress) => {
             <Button onPress={onPress}>
               Pay Now
             <Button>
-          })
+          }}
         />
       </View>
     );


### PR DESCRIPTION
The second code example on the readme had an error with the rednderButton prop. It used paranthesis for the props instead of curly braces