### PR TITLE
Enable Closing Of Modal n back button on Ntw Fail.

### DIFF
--- a/src/paystack.tsx
+++ b/src/paystack.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { useState, useEffect, forwardRef, useRef, useImperativeHandle } from 'react';
-import { Modal, View, ActivityIndicator, SafeAreaView } from 'react-native';
+import { Modal, View, ActivityIndicator, SafeAreaView, Text, TouchableOpacity } from 'react-native';
 import { WebView, WebViewNavigation } from 'react-native-webview';
 import { getAmountValueInKobo, getChannels } from './helper';
 import { PayStackProps, PayStackRef } from './types';
@@ -140,7 +140,7 @@ const Paystack: React.ForwardRefRenderFunction<React.ReactNode, PayStackProps> =
   };
 
   return (
-    <Modal style={{ flex: 1 }} visible={showModal} animationType="slide" transparent={false}>
+    <Modal style={{ flex: 1 }} visible={showModal} animationType="slide" transparent={false} onRequestClose={()=>setshowModal(false)}>
       <SafeAreaView style={{ flex: 1 }}>
         <WebView
           style={[{ flex: 1 }]}
@@ -159,6 +159,9 @@ const Paystack: React.ForwardRefRenderFunction<React.ReactNode, PayStackProps> =
         {isLoading && (
           <View>
             <ActivityIndicator size="large" color={activityIndicatorColor} />
+            <TouchableOpacity onPress={()=>setshowModal(false)}>
+              <Text style={{textAlign: "center"}} >Close</Text>
+            </TouchableOpacity>
           </View>
         )}
       </SafeAreaView>


### PR DESCRIPTION
Currently, when the modal pops up, you can't go back or close the modal esp. when the network fails and the PayStack can't be reached. 
This leaves the user stuck and forced to reset the application.