### PR TITLE
feat(RNPSW): expose the root modal's props for customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ function Pay(){
 | `autoStart`                          |                                                                       Auto start payment once page is opened                                                                        |                                           default: `false` |
 | `refNumber`                          |                                                                 Reference number, if you have already generated one                                                                 | default: `''+Math.floor((Math.random() * 1000000000) + 1)` |
 | `handleWebViewMessage`               |                                                                  Will be called when a WebView receives a message                                                                   |                                            default: `true` |
+| `modalProps`                         |     Can be used to extend the root modal props for example to handle closing like so `modalProps={{ onRequestClose: () => paystackWebViewRef.current.endTransaction() }}`     |                                            default: `nill` |
 
 
 ## [](https://github.com/just1and0/object-to-array-convert#contributions)Contributions

--- a/development/paystack.tsx
+++ b/development/paystack.tsx
@@ -25,6 +25,7 @@ const Paystack: React.ForwardRefRenderFunction<React.ReactNode, PayStackProps> =
     autoStart = false,
     onSuccess,
     activityIndicatorColor = 'green',
+    modalProps,
   },
   ref,
 ) => {
@@ -144,7 +145,7 @@ const Paystack: React.ForwardRefRenderFunction<React.ReactNode, PayStackProps> =
   };
 
   return (
-    <Modal style={{ flex: 1 }} visible={showModal} animationType="slide" transparent={false}>
+    <Modal style={{ flex: 1 }} visible={showModal} animationType="slide" transparent={false} {...modalProps}>
       <SafeAreaView style={{ flex: 1 }}>
         <WebView
           style={[{ flex: 1 }]}

--- a/development/types/index.ts
+++ b/development/types/index.ts
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { ModalProps } from 'react-native';
 export type Currency = 'NGN' | 'GHS' | 'USD' | 'ZAR';
 
 export type PaymentChannels = 'bank' | 'card' | 'qr' | 'ussd' | 'mobile_money';
@@ -29,6 +30,7 @@ export interface PayStackProps {
   autoStart?: boolean;
   activityIndicatorColor?: string;
   ref: React.ReactElement;
+  modalProps?: ModalProps;
 }
 
 export interface PayStackRef {


### PR DESCRIPTION
This PR allows the consumer to customize the root modal's props. One specific and important use case is to be able to dismiss the modal on back button press like so;

`modalProps={{ onRequestClose: () => paystackWebViewRef.current?.endTransaction() }}`

I wanted to document the usage in the Readme but the contribution guide says "All modifications should be made exclusively in the `/development` directory". Hoping to hear from the maintainer.