### PR TITLE
fix::I added bank_transfer to payment channels type

### DIFF
--- a/development/types/index.ts
+++ b/development/types/index.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 export type Currency = 'NGN' | 'GHS' | 'USD' | 'ZAR';
 
-export type PaymentChannels = 'bank' | 'card' | 'qr' | 'ussd' | 'mobile_money';
+export type PaymentChannels = 'bank' | 'card' | 'qr' | 'ussd' | 'mobile_money' | 'bank_transfer'
 
 export type SplitTypes = 'flat' | 'percentage';
 


### PR DESCRIPTION
I noticed `bank_transfer` was missing as a payment channel and I needed it as part of the payment channel in my project, so I proceeded to add it in this PR.