### PR TITLE
Stringify metadata object for html content

### DIFF
--- a/development/paystack.tsx
+++ b/development/paystack.tsx
@@ -86,7 +86,7 @@ const Paystack: React.ForwardRefRenderFunction<React.ReactNode, PayStackProps> =
           ? `split: ${JSON.stringify(split)},`
           : "",
         metadata
-          ? `metadata: ${metadata},`
+          ? `metadata: ${JSON.stringify(metadata)},`
           : `metadata: { custom_fields: [{ display_name: '${firstName} ${lastName}', variable_name: '${billingName}', value: '' }]},`,
       ];
       return params.filter(Boolean).join("\n");


### PR DESCRIPTION
When the optional metadata object is passed, the object was never converted to a string representation, which results in the html content using the default serialization and looking like this:

```
metadata: [object Object]
````

After applying JSON.stringify to the object, we'll get a valid string representation:

```
metadata: {"custom_fields":[{"display_name":"Test Custom Field","variable_name":"test_custom_field","value":"Test Value"}]},
```