### PR TITLE
Fix(rnpsw) remove default currency

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ const Checkout = () => {
 | Prop              | Type      | Default | Description                              |
 |-------------------|-----------|---------|------------------------------------------|
 | `publicKey`       | `string`  | —       | Your Paystack public key                 |
-| `currency`        | `string`  | `NGN`   | NGN / GHS / USD                          |
+| `currency`        | `string`  |   —     | Currency code  (optional)                 |
 | `defaultChannels` | `string[]`| `['card']`| Payment channels                        |
 | `debug`           | `boolean` | `false` | Show debug logs                          |
 | `onGlobalSuccess` | `func`    | —       | Called on all successful transactions    |

--- a/development/PaystackProvider.tsx
+++ b/development/PaystackProvider.tsx
@@ -17,7 +17,7 @@ export const PaystackContext = createContext<{
 
 export const PaystackProvider: React.FC<PaystackProviderProps> = ({
     publicKey,
-    currency = 'NGN',
+    currency,
     defaultChannels = ['card'],
     debug = false,
     children,
@@ -69,7 +69,7 @@ export const PaystackProvider: React.FC<PaystackProviderProps> = ({
                 amount: params.amount,
                 reference: params.reference || fallbackRef,
                 metadata: params.metadata,
-                currency,
+                ...(currency && { currency }),
                 channels: defaultChannels, 
                 plan: params.plan,
                 invoice_limit: params.invoice_limit,

--- a/development/types.ts
+++ b/development/types.ts
@@ -60,7 +60,7 @@ export interface SuccessResponse extends Response {
     data?: any;
 }
 
-export type Currency = 'NGN' | 'GHS' | 'USD' | 'ZAR' | 'KES';
+export type Currency = 'NGN' | 'GHS' | 'USD' | 'ZAR' | 'KES' | 'XOF';
 
 export type PaymentChannels = ('bank' | 'card' | 'qr' | 'ussd' | 'mobile_money' | 'bank_transfer' | 'eft' | 'apple_pay')[];
 

--- a/development/utils.ts
+++ b/development/utils.ts
@@ -90,7 +90,7 @@ export const generatePaystackParams = (config: {
   amount: number;
   reference: string;
   metadata?: object;
-  currency: Currency;
+  currency?: Currency;
   channels: PaymentChannels;
   plan?: string;
   invoice_limit?: number;
@@ -102,7 +102,7 @@ export const generatePaystackParams = (config: {
     `key: '${config.publicKey}'`,
     `email: '${config.email}'`,
     `amount: ${config.amount * 100}`,
-    `currency: '${config.currency}'`,
+    config.currency ? `currency: '${config.currency}'` : '',
     `reference: '${config.reference}'`,
     config.metadata ? `metadata: ${JSON.stringify(config.metadata)}` : '',
     config.channels ? `channels: ${JSON.stringify(config.channels)}` : '',


### PR DESCRIPTION
## Description
Addresses #212. Makes it such that if you don't pass a currency to PaystackProvider, your integration's default currency is used.

Also adds XOF as one of the supported currencies (Paystack is in beta in CIV)

## Issue URL
#212 