### PR TITLE
fix(RNPSW)-add-safearea-to-webview-modal

### DIFF
--- a/development/PaystackProvider.tsx
+++ b/development/PaystackProvider.tsx
@@ -1,5 +1,5 @@
 import React, { createContext, useCallback, useMemo, useState } from 'react';
-import { Modal, View, ActivityIndicator, } from 'react-native';
+import { Modal, SafeAreaView, ActivityIndicator, } from 'react-native';
 import { WebView, WebViewMessageEvent } from 'react-native-webview';
 import {
     PaystackParams,
@@ -89,7 +89,7 @@ export const PaystackProvider: React.FC<PaystackProviderProps> = ({
         <PaystackContext.Provider value={{ popup: { checkout, newTransaction } }}>
             {children}
             <Modal visible={visible} transparent animationType="slide">
-                <View style={styles.container}>
+                <SafeAreaView style={styles.container}>
                     <WebView
                         originWhitelist={["*"]}
                         source={{ html: paystackHTML }}
@@ -101,7 +101,7 @@ export const PaystackProvider: React.FC<PaystackProviderProps> = ({
                         onLoadEnd={() => debug && console.log('[Paystack] WebView Load End')}
                         renderLoading={() => <ActivityIndicator size="large" />}
                     />
-                </View>
+                </SafeAreaView>
             </Modal>
         </PaystackContext.Provider>
     );


### PR DESCRIPTION
## Description
I added a SafeAreaView to the Paystack WebView modal to fix the following issue
## Issue URL
[[Webview goes under StatusBar and SafeArea is not applied.](https://github.com/just1and0/React-Native-Paystack-WebView/issues/215#top)
#215](https://github.com/just1and0/React-Native-Paystack-WebView/issues/215)

## Before and After  
Add Image/video/gifs of changes 
Before: 
<img width="1242" height="2688" alt="image" src="https://github.com/user-attachments/assets/fb04969d-4336-409a-9c20-fb77dee2f996" />

After: 
<img width="379" height="823" alt="Screenshot 2025-08-09 at 12 21 32 AM" src="https://github.com/user-attachments/assets/779bbe23-c888-44b8-a845-bb520f825d58" />


| Before | After |
| --- | --- |
| **Visual:**  | **Visual:**   |
| **Functionality:**  | **Functionality:** |
